### PR TITLE
removed old code for svelte4 like dispatchers and also some unclear c…

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ export default [
   {languageOptions: { globals: globals.browser }},
   pluginJs.configs.recommended,
   {    
-    name: 'Frankie WebApp',
+    name: 'Svelte Marked',
     ignores: [
       'vite.config.js.*',
       'more.eslint.config.js',

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "svelte-marked",
   "description": "A markdown renderer for Svelte.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "packageManager": "yarn@4.6.0",
-  "engines": {
-    "node": ">=18"
-  },
   "main": "dist/sveltemarkdown.js",
   "module": "dist/sveltemarkdown.es.js",
   "jsnext:main": "dist/sveltemarkdown.es.js",
@@ -25,6 +22,10 @@
   ],
   "license": "MIT",
   "author": "Pablo Berganza <pablo@berganza.dev>",
+  "contributors": {
+    "name": "Daniele Dellafiore",
+    "url": "https://linktr.ee/ildella/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ildella/svelte-marked.git"

--- a/package.json
+++ b/package.json
@@ -39,17 +39,17 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@eslint/js": "9.19.0",
-    "@stylistic/eslint-plugin-js": "3.0.1",
+    "@eslint/js": "9.20.0",
+    "@stylistic/eslint-plugin-js": "3.1.0",
     "@sveltejs/vite-plugin-svelte": "5.0.3",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/svelte": "5.2.6",
-    "eslint": "9.19.0",
+    "eslint": "9.20.0",
     "eslint-plugin-svelte": "2.46.1",
     "eslint-plugin-vitest": "0.5.4",
     "globals": "15.14.0",
     "jsdom": "26.0.0",
-    "prettier": "3.4.2",
+    "prettier": "3.5.0",
     "rollup-plugin-analyzer": "4.0.0",
     "rollup-plugin-filesize": "10.0.0",
     "rollup-plugin-terser": "7.0.2",
@@ -62,7 +62,7 @@
   "dependencies": {
     "@types/marked": "6.0.0",
     "github-slugger": "2.0.0",
-    "marked": "15.0.6"
+    "marked": "15.0.7"
   },
   "peerDependencies": {
     "svelte": "^5"

--- a/src/SvelteMarkdown.svelte
+++ b/src/SvelteMarkdown.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { run } from 'svelte/legacy';
+  import { run } from 'svelte/legacy'
 
   import { setContext, createEventDispatcher, onMount } from 'svelte'
   import { marked } from 'marked'
@@ -9,52 +9,49 @@
   import { defaultOptions, defaultRenderers } from './markdown-parser'
   import { key } from './context'
 
-  /**
-   * @typedef {Object} Props
-   * @property {any} [source]
-   * @property {any} [renderers]
-   * @property {any} [options]
-   * @property {boolean} [isInline]
-   */
-
-  /** @type {Props} */
   let {
     source = [],
     renderers = {},
     options = {},
     isInline = false
-  } = $props();
+  } = $props()
 
-  const dispatch = createEventDispatcher()
+  // const dispatch = createEventDispatcher()
 
   let tokens = $state()
-  let mounted = $state()
+  // let mounted = $state()
 
   let preprocessed = $derived(Array.isArray(source))
   let slugger = $derived(source ? new Slugger : undefined)
   let combinedOptions = $derived({ ...defaultOptions, ...options })
-  run(() => {
+  let combinedRenderers = $derived({ ...defaultRenderers, ...renderers })
+
+  // function dispatch(eventName, detail) {
+  //   const event = new CustomEvent(eventName, { detail });
+  //   dispatchEvent(event);
+  // }
+  
+  $effect(() => {
     if (preprocessed) {
       tokens = source
     } else {
       const lexer = new marked.Lexer(combinedOptions)
       tokens = isInline ? lexer.inlineTokens(source) : lexer.lex(source)
-      dispatch('parsed', { tokens })
+      // dispatch('parsed', { tokens })
     }
-  });
-  let combinedRenderers = $derived({ ...defaultRenderers, ...renderers })
-  run(() => {
-    mounted && !preprocessed && dispatch('parsed', { tokens })
-  });
+  })
+  // run(() => {
+  //   mounted && !preprocessed && dispatch('parsed', { tokens })
+  // })
 
   setContext(key, {
     slug: (val) => slugger ? slugger.slug(val) : '',
     getOptions: () => combinedOptions
   })
 
-  onMount(() => {
-    mounted = true
-  })
+  // onMount(() => {
+  //   mounted = true
+  // })
 </script>
 
 <Parser {tokens} renderers={combinedRenderers} />

--- a/src/SvelteMarkdown.svelte
+++ b/src/SvelteMarkdown.svelte
@@ -1,6 +1,4 @@
 <script>
-  import { run } from 'svelte/legacy'
-
   import { setContext, createEventDispatcher, onMount } from 'svelte'
   import { marked } from 'marked'
   import Slugger from 'github-slugger'
@@ -16,42 +14,27 @@
     isInline = false
   } = $props()
 
-  // const dispatch = createEventDispatcher()
-
   let tokens = $state()
-  // let mounted = $state()
 
   let preprocessed = $derived(Array.isArray(source))
   let slugger = $derived(source ? new Slugger : undefined)
   let combinedOptions = $derived({ ...defaultOptions, ...options })
   let combinedRenderers = $derived({ ...defaultRenderers, ...renderers })
 
-  // function dispatch(eventName, detail) {
-  //   const event = new CustomEvent(eventName, { detail });
-  //   dispatchEvent(event);
-  // }
-  
   $effect(() => {
     if (preprocessed) {
       tokens = source
     } else {
       const lexer = new marked.Lexer(combinedOptions)
       tokens = isInline ? lexer.inlineTokens(source) : lexer.lex(source)
-      // dispatch('parsed', { tokens })
     }
   })
-  // run(() => {
-  //   mounted && !preprocessed && dispatch('parsed', { tokens })
-  // })
 
   setContext(key, {
     slug: (val) => slugger ? slugger.slug(val) : '',
     getOptions: () => combinedOptions
   })
 
-  // onMount(() => {
-  //   mounted = true
-  // })
 </script>
 
 <Parser {tokens} renderers={combinedRenderers} />

--- a/src/SvelteMarkdown.svelte
+++ b/src/SvelteMarkdown.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { setContext, createEventDispatcher, onMount } from 'svelte'
+  import { setContext } from 'svelte'
   import { marked } from 'marked'
   import Slugger from 'github-slugger'
 

--- a/src/renderers/Text.svelte
+++ b/src/renderers/Text.svelte
@@ -1,4 +1,4 @@
 <script>
-    let { text, raw, children } = $props();
+    let { children } = $props();
 </script>
 {@render children?.()}

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,8 +10,7 @@ import pkg from './package.json'
 const removeDist = (p) => p.replace('dist/', '')
 
 export default defineConfig({
-  plugins: [svelte({ hot: !process.env.VITEST })],
-  // plugins: [svelte()],
+  plugins: [svelte()],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@eslint/core@npm:0.11.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/1e0671d035c908175f445864a7864cf6c6a8b67a5dfba8c47b2ac91e2d3ed36e8c1f2fd81d98a73264f8677055559699d4adb0f97d86588e616fc0dc9a4b86c9
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^3.2.0":
   version: 3.2.0
   resolution: "@eslint/eslintrc@npm:3.2.0"
@@ -349,10 +358,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.19.0":
-  version: 9.19.0
-  resolution: "@eslint/js@npm:9.19.0"
-  checksum: 10c0/45dc544c8803984f80a438b47a8e578fae4f6e15bc8478a703827aaf05e21380b42a43560374ce4dad0d5cb6349e17430fc9ce1686fed2efe5d1ff117939ff90
+"@eslint/js@npm:9.20.0":
+  version: 9.20.0
+  resolution: "@eslint/js@npm:9.20.0"
+  checksum: 10c0/10e7b5b9e628b5192e8fc6b0ecd27cf48322947e83e999ff60f9f9e44ac8d499138bcb9383cbfa6e51e780d53b4e76ccc2d1753b108b7173b8404fd484d37328
   languageName: node
   linkType: hard
 
@@ -794,15 +803,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin-js@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@stylistic/eslint-plugin-js@npm:3.0.1"
+"@stylistic/eslint-plugin-js@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@stylistic/eslint-plugin-js@npm:3.1.0"
   dependencies:
     eslint-visitor-keys: "npm:^4.2.0"
     espree: "npm:^10.3.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10c0/e4f3a60189395198773ad223773458708035555a1835dcf4f6736c0a25a2951f72c9489f5ab115bad57802c55bcbc5a7be58a899cfd0c2952f163b9b4e5d1402
+  checksum: 10c0/9842e943e17f37f5e163f1994466346bd9302bb95a754764cf5255b102b099c6eabf8c44c257a94fa9cb5df68c766d36ec4a0b0b27e404ce223fef995441da71
   languageName: node
   linkType: hard
 
@@ -2075,16 +2084,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:9.19.0":
-  version: 9.19.0
-  resolution: "eslint@npm:9.19.0"
+"eslint@npm:9.20.0":
+  version: 9.20.0
+  resolution: "eslint@npm:9.20.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.0"
-    "@eslint/core": "npm:^0.10.0"
+    "@eslint/core": "npm:^0.11.0"
     "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:9.19.0"
+    "@eslint/js": "npm:9.20.0"
     "@eslint/plugin-kit": "npm:^0.2.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
@@ -2120,7 +2129,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/3b0dfaeff6a831de086884a3e2432f18468fe37c69f35e1a0a9a2833d9994a65b6dd2a524aaee28f361c849035ad9d15e3841029b67d261d0abd62c7de6d51f5
+  checksum: 10c0/5eb2d9b5ed85a0b022871d19719417d110afb07a4abfedd856ad03d9a821def5f6bc31d7c407ca27f56e5e66e39375300fd2b877017245eb99c44060d6c983bd
   languageName: node
   linkType: hard
 
@@ -3139,12 +3148,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:15.0.6":
-  version: 15.0.6
-  resolution: "marked@npm:15.0.6"
+"marked@npm:15.0.7":
+  version: 15.0.7
+  resolution: "marked@npm:15.0.7"
   bin:
     marked: bin/marked.js
-  checksum: 10c0/8f30972ac5fdf879353484bdd7717409c241d15031a58bbc483070dedb58e4b314c41c0b59b78e536658907c02ee149eaf4b9be221f198df97beae703f529d40
+  checksum: 10c0/0b9d07bace37bbf0548bae356c4184765afa4d2296ed0be4418aa4bb0ce703f323dc1a475125d536581f9fe264797e6265dd0b57499d97c0fe0f29bc6d016343
   languageName: node
   linkType: hard
 
@@ -3827,12 +3836,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.4.2":
-  version: 3.4.2
-  resolution: "prettier@npm:3.4.2"
+"prettier@npm:3.5.0":
+  version: 3.5.0
+  resolution: "prettier@npm:3.5.0"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/99e076a26ed0aba4ebc043880d0f08bbb8c59a4c6641cdee6cdadf2205bdd87aa1d7823f50c3aea41e015e99878d37c58d7b5f0e663bba0ef047f94e36b96446
+  checksum: 10c0/6c355d74c377f5622953229d92477e8b9779162e848db90fd7e06c431deb73585d31fafc4516cf5868917825b97b9ec7c87c8d8b8e03ccd9fc9c0b7699d1a650
   languageName: node
   linkType: hard
 
@@ -4515,20 +4524,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "svelte-marked@workspace:."
   dependencies:
-    "@eslint/js": "npm:9.19.0"
-    "@stylistic/eslint-plugin-js": "npm:3.0.1"
+    "@eslint/js": "npm:9.20.0"
+    "@stylistic/eslint-plugin-js": "npm:3.1.0"
     "@sveltejs/vite-plugin-svelte": "npm:5.0.3"
     "@testing-library/jest-dom": "npm:6.6.3"
     "@testing-library/svelte": "npm:5.2.6"
     "@types/marked": "npm:6.0.0"
-    eslint: "npm:9.19.0"
+    eslint: "npm:9.20.0"
     eslint-plugin-svelte: "npm:2.46.1"
     eslint-plugin-vitest: "npm:0.5.4"
     github-slugger: "npm:2.0.0"
     globals: "npm:15.14.0"
     jsdom: "npm:26.0.0"
-    marked: "npm:15.0.6"
-    prettier: "npm:3.4.2"
+    marked: "npm:15.0.7"
+    prettier: "npm:3.5.0"
     rollup-plugin-analyzer: "npm:4.0.0"
     rollup-plugin-filesize: "npm:10.0.0"
     rollup-plugin-terser: "npm:7.0.2"


### PR DESCRIPTION
In svelte 5 I Was getting this warning:

```
%c[svelte] legacy_recursive_reactive_block
%cDetected a migrated `$:` reactive block in `node_modules/svelte-marked/src/SvelteMarkdown.svelte` that both accesses and updates the same reactive value. This may cause recursive updates when converted to an `$effect`.
https://svelte.dev/e/legacy_recursive_reactive_block
```

this PR fixes it removing the now useless event dispatch code. 
Also removed more unused code and replaced `legacy/run` with new svelte5 rune `$effect`